### PR TITLE
Improve parallel proving pipeline and offload verification

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-network"
-version = "0.10.16"
+version = "0.10.17"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -30,11 +30,11 @@ use crate::register::{register_node, register_user};
 use crate::session::{run_headless_mode, run_tui_mode, setup_session};
 use crate::version::manager::validate_version_requirements;
 use clap::{ArgAction, Parser, Subcommand};
+use mimalloc::MiMalloc;
 use postcard::to_allocvec;
 use std::error::Error;
 use std::io::Write;
 use std::process::exit;
-use mimalloc::MiMalloc;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;

--- a/clients/cli/src/session/setup.rs
+++ b/clients/cli/src/session/setup.rs
@@ -97,7 +97,7 @@ pub async fn setup_session(
     if check_mem {
         warn_memory_configuration(max_threads);
     }
-    
+
     let num_workers: usize = max_threads.unwrap_or(1) as usize;
     // Create shutdown channel - only one shutdown signal needed
     let (shutdown_sender, _) = broadcast::channel(1);

--- a/clients/cli/src/workers/fetcher.rs
+++ b/clients/cli/src/workers/fetcher.rs
@@ -316,7 +316,7 @@ mod tests {
     fn create_test_fetcher() -> TaskFetcher {
         let (event_sender, _event_receiver) = mpsc::channel(100);
         let event_sender = crate::workers::core::EventSender::new(event_sender);
-        let config = WorkerConfig::new(Environment::Production, "test_client".to_string());
+        let config = WorkerConfig::new(Environment::Production, "test_client".to_string(), 1);
 
         TaskFetcher::new(
             12345,


### PR DESCRIPTION
## Summary
- refactor the authenticated proving pipeline to schedule proving jobs with JoinSet, enforce worker concurrency, and keep ordered results while handling cancellation
- run proof verification in a blocking task so CPU-heavy work no longer stalls the async runtime
- update the worker fetcher test configuration and lockfile version to match the new settings

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e24392818c8328b55473300b19801a