### PR TITLE
Reduce worker idle delay to improve throughput

### DIFF
--- a/clients/cli/src/workers/authenticated_worker.rs
+++ b/clients/cli/src/workers/authenticated_worker.rs
@@ -85,8 +85,8 @@ impl AuthenticatedWorker {
                         if should_exit {
                             break;
                         }
-                        // Natural rate limiting through work cycle
-                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        // Yield to the runtime without enforcing an artificial delay.
+                        tokio::task::yield_now().await;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- replace the fixed 100ms sleep between authenticated worker cycles with yielding to the runtime to avoid unnecessary idle time

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e25b6284c48328a44168a627dfbcdb